### PR TITLE
Implement `spec_menu_always` & `unlimited_team_changes` settings

### DIFF
--- a/cstrike/addons/amxmodx/configs/csdm/config.ini
+++ b/cstrike/addons/amxmodx/configs/csdm/config.ini
@@ -43,6 +43,12 @@ hide_hud_flags = "ft"
 ; Allow reset score for players by chat cmd '/rs'.
 allow_reset_score = 1
 
+; Allow to always show Spectator in choose team menu.
+spec_menu_always = 0
+
+; Remove restrictions from team change action.
+unlimited_team_changes = 0
+
 [protection]
 ; Number of seconds someone is respawned for.
 ; 0 = disable

--- a/cstrike/addons/amxmodx/configs/csdm/extraconfigs/_de_dust2.ini
+++ b/cstrike/addons/amxmodx/configs/csdm/extraconfigs/_de_dust2.ini
@@ -43,6 +43,12 @@ hide_hud_flags = "ft"
 ; Allow reset score for players by chat cmd '/rs'.
 allow_reset_score = 1
 
+; Allow to always show Spectator in choose team menu.
+spec_menu_always = 0
+
+; Remove restrictions from team change action.
+unlimited_team_changes = 0
+
 [protection]
 ; Number of seconds someone is respawned for.
 ; 0 = disable

--- a/cstrike/addons/amxmodx/configs/csdm/extraconfigs/_prefix_de.ini
+++ b/cstrike/addons/amxmodx/configs/csdm/extraconfigs/_prefix_de.ini
@@ -43,6 +43,12 @@ hide_hud_flags = "ft"
 ; Allow reset score for players by chat cmd '/rs'.
 allow_reset_score = 1
 
+; Allow to always show Spectator in choose team menu.
+spec_menu_always = 0
+
+; Remove restrictions from team change action.
+unlimited_team_changes = 0
+
 [protection]
 ; Number of seconds someone is respawned for.
 ; 0 = disable

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_equip_manager.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_equip_manager.sma
@@ -331,11 +331,13 @@ public MenuHandler_EquipMenu(const pPlayer, const menu, const item) {
 		case em_newWeapons: {
 			g_iNumSecondary ? MenuShow_SecondaryWeapons(pPlayer) : MenuShow_PrimaryWeapons(pPlayer)
 			g_bAlwaysRandom[pPlayer] = false
+			g_bOpenMenu[pPlayer] = true
 		}
 		case em_previous: {
 			PreviousWeapons(pPlayer, g_aArrays[Secondary], g_iPreviousSecondary[pPlayer])
 			PreviousWeapons(pPlayer, g_aArrays[Primary], g_iPreviousPrimary[pPlayer])
 			g_bAlwaysRandom[pPlayer] = false
+			g_bOpenMenu[pPlayer] = true
 		}
 		case em_dontShowAgain: {
 			PreviousWeapons(pPlayer, g_aArrays[Secondary], g_iPreviousSecondary[pPlayer])
@@ -349,6 +351,7 @@ public MenuHandler_EquipMenu(const pPlayer, const menu, const item) {
 			g_iPreviousSecondary[pPlayer] = RandomWeapons(pPlayer, g_aArrays[Secondary], g_iNumSecondary)
 			g_iPreviousPrimary[pPlayer] = RandomWeapons(pPlayer, g_aArrays[Primary], g_iNumPrimary)
 			g_bAlwaysRandom[pPlayer] = false
+			g_bOpenMenu[pPlayer] = true
 		}
 		case em_always_random: {
 			g_iPreviousSecondary[pPlayer] = RandomWeapons(pPlayer, g_aArrays[Secondary], g_iNumSecondary)

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
@@ -60,6 +60,9 @@ public plugin_init()
 	}
 
 	g_eCustomForwards[iFwdPlayerResetScore] = CreateMultiForward("CSDM_PlayerResetScore", ET_IGNORE, FP_CELL)
+
+	bind_pcvar_num(create_cvar("csdm_spec_menu_always", "1"), csdm_spec_menu_always)
+	bind_pcvar_num(create_cvar("csdm_unlimited_team_changes", "1"), csdm_unlimited_team_changes)
 }
 
 public plugin_cfg()

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
@@ -1,7 +1,7 @@
 #include <amxmodx>
 #include <hamsandwich>
 #include <csdm>
-
+#include <reapi>
 
 #define IsPlayer(%1)				(1 <= (%1) <= MaxClients)
 
@@ -20,6 +20,9 @@ new HamHook:g_hSecondaryAttack[sizeof(g_szWeaponList)], HamHook:g_hAddToPlayer[s
 new g_bWeaponState[MAX_CLIENTS + 1][CSW_P90 + 1]
 
 new bool:g_bWeaponStateRemember = true, g_bitHideHudFlags, g_iRefillClip = 1, bool:g_bAllowResetScore = true
+
+new bool: csdm_spec_menu_always = true
+new bool: csdm_unlimited_team_changes = true
 
 #define register_trigger_clcmd(%0,%1) \
 	for (new iter = 0; iter < sizeof(BASE_CHAT_TRIGGERS); iter++) \
@@ -46,6 +49,10 @@ public plugin_init()
 		DisableHamForward(g_hAddToPlayer[i] = RegisterHam(Ham_Item_AddToPlayer, g_szWeaponList[i], "CBasePlayerItem_AddToPlayer", .Post = true))
 		DisableHamForward(g_hSecondaryAttack[i] = RegisterHam(Ham_Weapon_SecondaryAttack, g_szWeaponList[i], "CBasePlayerItem_SecAttack", .Post = true))
 	}
+
+	RegisterHookChain(RG_HandleMenu_ChooseTeam, "HandleMenu_ChooseTeam_Pre", .post = false)
+	RegisterHookChain(RG_HandleMenu_ChooseTeam, "HandleMenu_ChooseTeam", .post = true)
+	RegisterHookChain(RG_ShowVGUIMenu, "ShowVGUIMenu_Pre", .post = false)
 
 	new const CMDS_ResetScore[][] = { "rs", "resetscore" };
 	for(new i; i < sizeof(CMDS_ResetScore); i++) {
@@ -118,6 +125,30 @@ public CBasePlayerItem_AddToPlayer(const pWeapon, const pPlayer)
 	}
 
 	return HAM_IGNORED
+}
+
+public HandleMenu_ChooseTeam_Pre(const index, const MenuChooseTeam:slot)
+{
+	if(csdm_spec_menu_always)
+		set_member_game(m_bFreezePeriod, true)
+}
+
+public HandleMenu_ChooseTeam(const index, const MenuChooseTeam:slot)
+{
+	if(csdm_spec_menu_always)
+		set_member_game(m_bFreezePeriod, false)
+
+	if(csdm_unlimited_team_changes)
+		set_member(index, m_bTeamChanged, false)
+}
+
+public ShowVGUIMenu_Pre(const index, VGUIMenu:menuType, const bitsSlots, szOldMenu[])
+{
+	if(csdm_spec_menu_always && strcmp(szOldMenu, "#IG_Team_Select") == 0)
+	{
+		SetHookChainArg(3, ATYPE_INTEGER, (bitsSlots | MENU_KEY_6))
+		SetHookChainArg(4, ATYPE_STRING, "#IG_Team_Select_Spect")
+	}
 }
 
 public Message_HideWeapon(const iMsgId, const iMsgDest, const iMsgEntity)

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
@@ -152,8 +152,7 @@ public HandleMenu_ChooseTeam(const index, const MenuChooseTeam:slot)
 
 public ShowVGUIMenu_Pre(const index, VGUIMenu:menuType, const bitsSlots, szOldMenu[])
 {
-	if(csdm_spec_menu_always && strcmp(szOldMenu, "#IG_Team_Select") == 0)
-	{
+	if(csdm_spec_menu_always && menuType == VGUI_Menu_Team) {
 		SetHookChainArg(3, ATYPE_INTEGER, (bitsSlots | MENU_KEY_6))
 		SetHookChainArg(4, ATYPE_STRING, "#IG_Team_Select_Spect")
 	}

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
@@ -145,6 +145,9 @@ public HandleMenu_ChooseTeam(const index, const MenuChooseTeam:slot)
 
 	if(csdm_unlimited_team_changes)
 		set_member(index, m_bTeamChanged, false)
+
+	if(get_member(index, m_iTeam) != TEAM_SPECTATOR)
+		rg_internal_cmd(index, "joinclass", "5")
 }
 
 public ShowVGUIMenu_Pre(const index, VGUIMenu:menuType, const bitsSlots, szOldMenu[])

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
@@ -132,6 +132,8 @@ public CBasePlayerItem_AddToPlayer(const pWeapon, const pPlayer)
 
 public HandleMenu_ChooseTeam_Pre(const index, const MenuChooseTeam:slot)
 {
+	set_member(index, m_bForceShowMenu, true)
+
 	if(csdm_spec_menu_always)
 		set_member_game(m_bFreezePeriod, true)
 }

--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_misc.sma
@@ -21,8 +21,8 @@ new g_bWeaponState[MAX_CLIENTS + 1][CSW_P90 + 1]
 
 new bool:g_bWeaponStateRemember = true, g_bitHideHudFlags, g_iRefillClip = 1, bool:g_bAllowResetScore = true
 
-new bool: csdm_spec_menu_always = true
-new bool: csdm_unlimited_team_changes = true
+new bool: csdm_spec_menu_always
+new bool: csdm_unlimited_team_changes
 
 #define register_trigger_clcmd(%0,%1) \
 	for (new iter = 0; iter < sizeof(BASE_CHAT_TRIGGERS); iter++) \
@@ -60,9 +60,6 @@ public plugin_init()
 	}
 
 	g_eCustomForwards[iFwdPlayerResetScore] = CreateMultiForward("CSDM_PlayerResetScore", ET_IGNORE, FP_CELL)
-
-	bind_pcvar_num(create_cvar("csdm_spec_menu_always", "1"), csdm_spec_menu_always)
-	bind_pcvar_num(create_cvar("csdm_unlimited_team_changes", "1"), csdm_unlimited_team_changes)
 }
 
 public plugin_cfg()
@@ -194,7 +191,15 @@ public ReadCfg(const szLineData[], const iSectionID)
 	}
 	else if(equali(szKey, "allow_reset_score"))
 	{
-		g_bAllowResetScore = true;
+		g_bAllowResetScore = true
+	}
+	else if(equali(szKey, "spec_menu_always"))
+	{
+		csdm_spec_menu_always = true
+	}
+	else if(equali(szKey, "unlimited_team_changes"))
+	{
+		csdm_unlimited_team_changes = true
 	}
 }
 


### PR DESCRIPTION
#44

Added new settings:
```ini
[misc]
; Allow to always show Spectator in choose team menu.
spec_menu_always = 0

; Remove restrictions from team change action.
unlimited_team_changes = 0
```